### PR TITLE
Fix most recent order query

### DIFF
--- a/query.py
+++ b/query.py
@@ -22,7 +22,7 @@ response = table.query(IndexName='gsi_1',KeyConditionExpression=Key('sk').eq('pr
 print(response['Items'])
 
 # e. Get the most recent 25 orders
-response = table.query(IndexName='gsi_1',KeyConditionExpression=Key('sk').eq('ORDER'), Limit=25)
+response = table.query(IndexName='gsi_1',KeyConditionExpression=Key('sk').eq('ORDER'), Limit=25, ScanIndexForward=False)
 print(response['Items'])
 
 # f. Get shippers by name


### PR DESCRIPTION
The dates of the orders are timestamps in strings, so the most recent orders are sorted lexicographically last in the index. So the query needs to scan from the end with `ScanIndexForward = False`.